### PR TITLE
Escape ( & ) from url before constructing regex

### DIFF
--- a/lib/types/path.js
+++ b/lib/types/path.js
@@ -77,7 +77,7 @@ function Path (api, path, definition, definitionFullyResolved, pathToDefinition)
   this.path = path;
   this.pathToDefinition = pathToDefinition;
   this.ptr = JsonRefs.pathToPtr(pathToDefinition);
-  this.regexp = pathToRegexp(basePathPrefix + path.replace(/\{/g, ':').replace(/\}/g, ''));
+  this.regexp = pathToRegexp(basePathPrefix + path.replace(/\(/g, '\\(').replace(/\)/g, '\\)').replace(/\{/g, ':').replace(/\}/g, ''));
 
   // Assign local properties from the Swagger definition properties
   _.assign(this, definitionFullyResolved);


### PR DESCRIPTION
fixes https://github.com/Azure/openapi-validation-tools/issues/79

@amarzavery Please review!!