### PR TITLE
If there is no content-type set do not validate it

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -243,8 +243,11 @@ Operation.prototype.validateRequest = function (req) {
     warnings: []
   };
 
-  // Validate the Content-Type if there is a set of expected consumes
-  if (this.consumes.length > 0) {
+  // Validate the Content-Type if there is a set of expected consumes. Also we will validate only if there 
+  // is a content-type set in the request headers as many times it happens that it is not set at all and 
+  // the service works fine. Going by the RFC www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1 mentioned above we would need to assume 'application/octet-stream'
+  // which in most cases would not be true so it would produce a lot of noise without adding much value.
+  if (this.consumes.length > 0 && helpers.getHeaderValue(req.headers, 'content-type')) {
     helpers.validateContentType(helpers.getContentType(req.headers), this.consumes, results);
   }
 


### PR DESCRIPTION
If there is no content type set in the request it will be assumed to be `application/octet-stream` which IS in fact in accordance with the RFC. 

That being said a lot of traffic just doesn't have the content type set but there is no problem on the service side and this check does nothing but to create noise for that case as INVALID_CONTENT_TYPE since it is assumed to be `application/octet-stream`.

The check will continue to happen if the swagger specifies something and the request actually specifies something else. 

Finally, if indeed the content type in the swagger is `application/octet-stream` and it is not specified in the request then it is ok not to check because either way by default it would be that and the check would pass.