### PR TITLE
Respect modelasstring true

### DIFF
--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -5,6 +5,7 @@ function enumValidator (report, schema, json) {
   var match = false;
   var idx = schema.enum.length;
   var caseInsensitiveMatch = false;
+  var areExtraEnumValuesAllowed = false;
 
   while (idx--) {
     if (json === schema.enum[idx]) {
@@ -19,6 +20,7 @@ function enumValidator (report, schema, json) {
     }
   }
 
+  areExtraEnumValuesAllowed = schema['x-ms-enum'] && schema['x-ms-enum'].modelAsString;
   if (caseInsensitiveMatch === true) {
     report.addCustomError(
       'ENUM_CASE_MISMATCH',
@@ -27,7 +29,7 @@ function enumValidator (report, schema, json) {
       null,
       schema.description
     );
-  } else if (match === false) {
+  } else if (match === false && !areExtraEnumValuesAllowed) {
     report.addError('ENUM_MISMATCH', [json], null, schema.description);
   }
 }


### PR DESCRIPTION
 If an enum has specified x-ms-enum.modelAsString === true, don't report an unspecified enum value as an error.