### PR TITLE
Add check for required property on x-ms-mutability type check

### DIFF
--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -52,6 +52,7 @@ function requiredPropertyValidator (report, schema, json) {
 
     // If a response has x-ms-mutability property and its missing the read we can skip this step
     if (this.validateOptions && this.validateOptions.isResponse && xMsMutability && xMsMutability.indexOf('read') === -1) {
+      schema.properties[`${requiredPropertyName}`].isRequired = true;
       continue;
     }
     if (json[requiredPropertyName] === undefined) {
@@ -71,7 +72,7 @@ function typeValidator (report, schema, json) {
   var xMsMutabilityAllowsNullType = schema['x-ms-mutability'] && schema['x-ms-mutability'].indexOf('read') === -1;
   var isResponse = this.validateOptions && this.validateOptions.isResponse;
 
-  if (isResponse && xMsMutabilityAllowsNullType) {
+  if (isResponse && xMsMutabilityAllowsNullType && schema.isRequired) {
     return;
   }
   if (typeof schema.type === 'string') {


### PR DESCRIPTION
We need this extra check as for non-required properties we add an extra Null type in ONE_OF.

Given that here we accept Null, we will get a ONE_OF_MULTIPLE error since both of the one of will be correct.

